### PR TITLE
Remove non-existent sky/services/gcm target

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -13,8 +13,8 @@ $GCLOUD auth activate-service-account --key-file ../gcloud_key_file.json
 
 if [ $TRAVIS_OS_NAME = "linux" ]; then
   if [ $BUILD_TARGET = "device" ]; then
-    ./sky/tools/gn --release --android --enable-firebase --enable-gcm
-    ninja -C out/android_Release apks/SkyShell.apk flutter.mojo sky/services/gcm sky/services/firebase
+    ./sky/tools/gn --release --android --enable-firebase
+    ninja -C out/android_Release apks/SkyShell.apk flutter.mojo sky/services/firebase
     STORAGE_BASE_URL=gs://mojo_infra/flutter/$GIT_REVISION/android-arm
 
     # TODO(mpcomplete): stop bundling classes.dex once
@@ -29,12 +29,6 @@ if [ $TRAVIS_OS_NAME = "linux" ]; then
       out/android_Release/icudtl.dat
 
     $GSUTIL cp /tmp/artifacts.zip $STORAGE_BASE_URL/artifacts.zip
-
-    # Upload GCM service libraries.
-    $GSUTIL cp out/android_Release/gen/sky/services/gcm/gcm_lib.dex.jar \
-      $STORAGE_BASE_URL/gcm/gcm_lib.dex.jar
-    $GSUTIL cp out/android_Release/gen/sky/services/gcm/interfaces_java.dex.jar \
-      $STORAGE_BASE_URL/gcm/interfaces_java.dex.jar
 
     # Upload Firebase service libraries.
     $GSUTIL cp out/android_Release/gen/sky/services/firebase/firebase_lib.dex.jar \


### PR DESCRIPTION
This target no longer exists, which means we'll fail to build when we try to build it.